### PR TITLE
HTTP/2

### DIFF
--- a/default
+++ b/default
@@ -20,7 +20,7 @@ server {
 }
 
 server {
-  listen 443 ssl;
+  listen 443 ssl http2;
   server_name api.static.land;
   client_max_body_size 100M;
 


### PR DESCRIPTION
nginx supports HTTP/2 from version 1.9.5