### PR TITLE
better gzip compression

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -22,6 +22,13 @@ http {
 
   gzip on;
   gzip_disable "msie6";
+  gzip_vary on;
+  gzip_proxied any;
+  gzip_comp_level 6;
+  gzip_buffers 16 8k;
+  gzip_http_version 1.1;
+  gzip_min_length 256;
+  gzip_types text/plain text/css application/json  application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript application/vnd.ms-fontobject application/x-font-ttf font/opentype image/svg+xml image/x-icon;
 
   include /etc/nginx/conf.d/*.conf;
   include /etc/nginx/sites-enabled/*;


### PR DESCRIPTION
I think the current config doesn't compress JS or CSS (at least my site at staticland is not being compressed).

The suggested values are from here:
https://www.digitalocean.com/community/tutorials/how-to-add-the-gzip-module-to-nginx-on-ubuntu-14-04

There are other tutorials around, with different values, but I think that at least the `gzip_types` is important to allow compression to more than HTML.

(Added `application/javascript` to `gzip_types`)